### PR TITLE
Add notice for mongo DB on newer kernel versions

### DIFF
--- a/docker-compose.yml.template
+++ b/docker-compose.yml.template
@@ -4,6 +4,10 @@ services:
   fe2_database:
     image: mongo:8.0.26
     container_name: fe2_database
+    # Required to be set, if the linux host uses a kernel >= 6.19. A change in MongoDB 8 (https://jira.mongodb.org/browse/SERVER-121912) introduced a
+    # silent crash.
+    #environment:
+    #  - GLIBC_TUNABLES=glibc.cpu.hwcaps=-SHSTK
     logging:
       driver: none
     ports:


### PR DESCRIPTION
MongoDB 8 on newer kernel versions (>= 6.19) crashes silently after ~29s. The change on MongoDB was introduced with https://jira.mongodb.org/browse/SERVER-121912 

Blog article about this: https://neckar.it/blog/mongodb-8-stirbt-leise-wenn-die-cpu-die-datenbank-fuer-einen-angreifer-haelt/